### PR TITLE
Fix playbook privilege escalation

### DIFF
--- a/deploymatrix.yml
+++ b/deploymatrix.yml
@@ -2,6 +2,7 @@
 - name: Deploy Matrix stack with Podman
   hosts: all
   gather_facts: false
+  become: true
   vars:
     synapse_image: docker.io/matrixdotorg/synapse:latest
     postgres_image: docker.io/library/postgres:16-alpine


### PR DESCRIPTION
## Summary
- run tasks with root privileges by default

## Testing
- `ansible-lint deploymatrix.yml`
- `ansible-playbook -i inventory/hosts deploymatrix.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6864461334a4832287658bf11a872e5c